### PR TITLE
Fix aws_ses_receipt_rule.default: expected s3_action.0.position to be at least (1), got 0

### DIFF
--- a/ses.tf
+++ b/ses.tf
@@ -16,12 +16,12 @@ resource "aws_ses_receipt_rule" "default" {
 
   s3_action {
     bucket_name = "${aws_s3_bucket.default.bucket}"
-    position    = 0
+    position    = 1
   }
 
   lambda_action {
     function_arn = "${aws_lambda_function.default.arn}"
-    position     = 1
+    position     = 2
   }
 
   depends_on = ["aws_ses_receipt_rule_set.default", "aws_s3_bucket_policy.default"]


### PR DESCRIPTION
## What
* Changes s3 action indexes

## Why
* Fix https://github.com/cloudposse/terraform-aws-ses-lambda-forwarder/issues/4