### PR TITLE
Fix build

### DIFF
--- a/Makefile.ses
+++ b/Makefile.ses
@@ -1,7 +1,7 @@
 ifndef CI
-NPM ?= docker run -it -v $(shell pwd)/lambda/:/code -w /code --entrypoint=npm node:8.10-alpine
+BUILD ?= docker run -it -v $(shell pwd)/lambda/:/code -w /code --entrypoint=npm node:10-alpine update --unsafe-perm=true --allow-root
 else
-NPM ?= npm
+BUILD ?= cd lambda/ && npm update && cd ..
 endif
 
 # Ensures that a variable is defined
@@ -11,7 +11,7 @@ endef
 
 ## Build lambda package
 build:
-	$(NPM) update
+	$(BUILD)
 	sudo chmod -R 777 lambda
 	mkdir -p artifacts
 	cd lambda && zip -r ../artifacts/lambda.zip *

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -209,6 +210,7 @@ Available targets:
 | ses\_receipt\_rule\_name | The name of the SES receipt rule |
 | ses\_receipt\_rule\_set\_name | The name of the SES receipt rule set |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -55,3 +56,4 @@
 | ses\_receipt\_rule\_name | The name of the SES receipt rule |
 | ses\_receipt\_rule\_set\_name | The name of the SES receipt rule set |
 
+<!-- markdownlint-restore -->


### PR DESCRIPTION
## what

* Fixes build.
* Updates node used during build to v10.
* Adds `--unsafe-perm=true` and `--allow-root` 

## why

* When module is applied in it's current form, the artifacts that are pulled do not contain node_modules required for execution
* Updated node because it better aligns with lambda runtime support and adds support for `--unsafe-perms=true` and `--allow-root` which helps when using podman 

## references

https://github.com/cloudposse/terraform-aws-ses-lambda-forwarder/issues/17

