### PR TITLE
mfa_delete removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ Available targets:
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | lambda\_runtime | Lambda runtime | `string` | `"nodejs12.x"` | no |
-| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,7 +33,6 @@
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | lambda\_runtime | Lambda runtime | `string` | `"nodejs12.x"` | no |
-| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |

--- a/examples/complete/fixtures.us-east-1.tfvars
+++ b/examples/complete/fixtures.us-east-1.tfvars
@@ -23,5 +23,3 @@ lambda_runtime = "nodejs12.x"
 artifact_url = "https://artifacts.cloudposse.com/terraform-external-module-artifact/example/test.zip"
 
 artifact_filename = "lambda.zip"
-
-mfa_delete = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -16,7 +16,6 @@ module "ses_lambda_forwarder" {
 
   artifact_url      = var.artifact_url
   artifact_filename = var.artifact_filename
-  mfa_delete        = var.mfa_delete
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -37,8 +37,3 @@ variable "artifact_filename" {
   type        = string
   description = "Artifact filename"
 }
-
-variable "mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-}

--- a/s3.tf
+++ b/s3.tf
@@ -1,13 +1,13 @@
 resource "aws_s3_bucket" "default" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
+  #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
   bucket        = module.this.id
   region        = var.region
   force_destroy = true
 
   versioning {
-    enabled    = var.versioning_enabled
-    mfa_delete = var.mfa_delete
+    enabled = var.versioning_enabled
   }
 
   dynamic "logging" {

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,6 @@ variable "versioning_enabled" {
   description = "A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket"
 }
 
-variable "mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-  default     = true
-}
-
 variable "tracing_config_mode" {
   type        = string
   description = "Can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service."


### PR DESCRIPTION
## what
* `mfa_delete` removed
* Bridgecrew check `Ensure S3 bucket has MFA delete enabled` skipped

## why
* Because terraform doesn't support this argument to be toggled (https://github.com/hashicorp/terraform-provider-aws/issues/629).
* To satisfy Bridgecrew compliance scan

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/629

