### PR TITLE
fix: Adding environment variable

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_EC2_METADATA_DISABLED: true
 
       - name: Test Download from CDN
         run: curl -fsSL -o /dev/null https://artifacts.cloudposse.com/${{ github.event.repository.name }}/${{ github.sha }}/lambda.zip


### PR DESCRIPTION
## what
* Setting environment variable `AWS_EC2_METADATA_DISABLED: true` as a solution

## why
* github actions is unable to push artifacts to s3 because of an error with the awscli.

## references
* https://github.com/aws/aws-cli/issues/5234#issuecomment-705831465
* related to https://github.com/cloudposse/terraform-aws-ses-lambda-forwarder/issues/13