### PR TITLE
Upgrade terraform-external-module-artifact to 0.8.0 for ARM compatibility

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role_policy_attachment" "lambda" {
 
 module "artifact" {
   source      = "cloudposse/module-artifact/external"
-  version     = "0.7.1"
+  version     = "0.8.0"
   filename    = var.artifact_filename
   module_name = "terraform-aws-ses-lambda-forwarder"
   module_path = path.module


### PR DESCRIPTION

## what
terraform-external-module-artifact 0.7.1 still relies on hashicorp/template which is not compatible with ARM. 

0.8.0 is: https://github.com/cloudposse/terraform-external-module-artifact/compare/0.7.1...0.8.0

## why
hashicorp/template is not compatible with ARM64. The latest release of this module switched to template/cloudposse, but the external module that is called in lambda.tf still uses hashicorp/template in version 0.7.1. Upgrading to 0.8.0 solves this issue.

There are no breaking changes between 0.7.1 and 0.8.0.  

## references
https://github.com/cloudposse/terraform-external-module-artifact/compare/0.7.1...0.8.0
